### PR TITLE
Added note for some instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $ source konishienv/bin/activate
 ```bash
 $ pip install -r requirements.txt
 ```
+- Note: On some distros like Ubuntu it is ```pip3``` not ```pip```. Command may break because it's looking for python2.  
 
 **Setting up the database** 
 


### PR DESCRIPTION
On some distros you have to specity pip3 instead of pip because there might be multiple versions of python installed. Added a note for this.